### PR TITLE
2559: livestream_tagsにインデックスを追加

### DIFF
--- a/webapp/sql/initdb.d/10_schema.sql
+++ b/webapp/sql/initdb.d/10_schema.sql
@@ -55,7 +55,8 @@ CREATE TABLE `tags` (
 CREATE TABLE `livestream_tags` (
   `id` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
   `livestream_id` BIGINT NOT NULL,
-  `tag_id` BIGINT NOT NULL
+  `tag_id` BIGINT NOT NULL,
+  INDEX `idx_livestream_tags_01` (`livestream_id`)
 ) ENGINE=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
 
 -- ライブ配信視聴履歴


### PR DESCRIPTION
```
2024-10-10T11:35:43.726Z	warn	staff-logger	scenario/viewer.go:101	view: failed to get livecomments: ベンチマーク走行が継続できないエラーが発生しました

2024-10-10T11:35:43.727Z	warn	staff-logger	scenario/viewer.go:142	view: failed to leave from livestream: ベンチマーク走行が継続できないエラーが発生しました

2024-10-10T11:35:43.727Z	warn	staff-logger	scenario/viewer.go:101	view: failed to get livecomments: ベンチマーク走行が継続できないエラーが発生しました

2024-10-10T11:35:43.727Z	warn	staff-logger	scenario/viewer.go:101	view: failed to get livecomments: ベンチマーク走行が継続できないエラーが発生しました

2024-10-10T11:35:43.727Z	warn	staff-logger	scenario/viewer.go:142	view: failed to leave from livestream: ベンチマーク走行が継続できないエラーが発生しました

2024-10-10T11:35:43.728Z	warn	staff-logger	scenario/streamer.go:160	streamer_moderate: failed to moderate: ベンチマーク走行が継続できないエラーが発生しました

2024-10-10T11:35:43.728Z	warn	staff-logger	scenario/streamer.go:204	aggressive streamer moderate: failed to moderate: ベンチマーク走行が継続できないエラーが発生しました

2024-10-10T11:35:43.909Z	info	staff-logger	scenario/viewer.go:64	get livestream
2024-10-10T11:35:43.910Z	warn	staff-logger	scenario/viewer.go:67	view: failed to get livestream from pool: context deadline exceeded

2024-10-10T11:35:43.911Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "rika070", "livestream_id": 7524, "error": "ベンチマーク走行が継続できないエラーが発生しました"}
2024-10-10T11:35:43.911Z	warn	staff-logger	scenario/viewer.go:121	view: failed to post livecomment: ベンチマーク走行が継続できないエラーが発生しました

2024-10-10T11:35:43.913Z	info	staff-logger	bench/bench.go:260	ベンチマーク走行時間: 1m0.241423293s
2024-10-10T11:35:43.914Z	info	isupipe-benchmarker	ベンチマーク走行終了
2024-10-10T11:35:43.914Z	info	isupipe-benchmarker	最終チェックを実施します
2024-10-10T11:35:43.919Z	info	isupipe-benchmarker	最終チェックが成功しました
2024-10-10T11:35:43.920Z	info	isupipe-benchmarker	重複排除したログを以下に出力します
2024-10-10T11:35:43.920Z	info	staff-logger	bench/bench.go:277	ベンチエラーを収集します
2024-10-10T11:35:43.921Z	info	staff-logger	bench/bench.go:285	内部エラーを収集します
2024-10-10T11:35:43.922Z	info	staff-logger	bench/bench.go:301	シナリオカウンタを出力します
2024-10-10T11:35:43.924Z	info	isupipe-benchmarker	配信を最後まで視聴できた視聴者数	{"viewers": 8}
2024-10-10T11:35:43.925Z	info	staff-logger	bench/bench.go:323	[シナリオ aggressive-streamer-moderate] 13 回成功
2024-10-10T11:35:43.925Z	info	staff-logger	bench/bench.go:323	[シナリオ dns-watertorture-attack] 6 回成功
2024-10-10T11:35:43.926Z	info	staff-logger	bench/bench.go:323	[シナリオ streamer-cold-reserve] 30 回成功
2024-10-10T11:35:43.927Z	info	staff-logger	bench/bench.go:323	[シナリオ streamer-moderate] 14 回成功
2024-10-10T11:35:43.927Z	info	staff-logger	bench/bench.go:323	[シナリオ viewer-report] 29 回成功, 3 回失敗
2024-10-10T11:35:43.928Z	info	staff-logger	bench/bench.go:323	[シナリオ viewer-spam] 15 回成功
2024-10-10T11:35:43.928Z	info	staff-logger	bench/bench.go:323	[シナリオ viewer] 8 回成功
2024-10-10T11:35:43.928Z	info	staff-logger	bench/bench.go:323	[失敗シナリオ viewer-report-fail] 3 回失敗
2024-10-10T11:35:43.928Z	info	staff-logger	bench/bench.go:329	DNSAttacker並列数: 2
2024-10-10T11:35:44.018Z	info	staff-logger	bench/bench.go:330	名前解決成功数: 1097
2024-10-10T11:35:44.018Z	info	staff-logger	bench/bench.go:331	名前解決失敗数: 0
2024-10-10T11:35:44.019Z	info	staff-logger	bench/bench.go:335	スコア: 2559
```