### PR TITLE
タグ取得のn1解消

### DIFF
--- a/webapp/go/livestream_handler.go
+++ b/webapp/go/livestream_handler.go
@@ -423,22 +423,14 @@ func fillLivestreamResponse(ctx context.Context, livestreamModel LivestreamModel
 		return Livestream{}, err
 	}
 
-	var livestreamTagModels []*LivestreamTagModel
-	if err := dbConn.SelectContext(ctx, &livestreamTagModels, "SELECT * FROM livestream_tags WHERE livestream_id = ?", livestreamModel.ID); err != nil {
+	var tagModels []*TagModel
+	if err := dbConn.SelectContext(ctx, &tagModels, "SELECT t.id, t.name FROM livestream_tags lt INNER JOIN tags t ON t.id = lt.tag_id WHERE livestream_id = ?", livestreamModel.ID); err != nil {
 		return Livestream{}, err
 	}
 
-	tags := make([]Tag, len(livestreamTagModels))
-	for i := range livestreamTagModels {
-		tagModel := TagModel{}
-		if err := dbConn.GetContext(ctx, &tagModel, "SELECT * FROM tags WHERE id = ?", livestreamTagModels[i].TagID); err != nil {
-			return Livestream{}, err
-		}
-
-		tags[i] = Tag{
-			ID:   tagModel.ID,
-			Name: tagModel.Name,
-		}
+	tags := make([]Tag, len(tagModels))
+	for i, v := range tagModels {
+		tags[i] = Tag{ID: v.ID, Name: v.Name}
 	}
 
 	livestream := Livestream{


### PR DESCRIPTION
## 概要

## 実行結果

### ベンチマーク

```

2024-11-28T15:10:23.018Z	warn	staff-logger	scenario/streamer.go:160	streamer_moderate: failed to moderate: ベンチマーク走行が継続できないエラーが発生しました

2024-11-28T15:10:23.019Z	warn	staff-logger	scenario/streamer.go:139	streamer_moderate: failed to visit livestream admin: ベンチマーク走行が継続できないエラーが発生しました

2024-11-28T15:10:23.196Z	info	staff-logger	bench/bench.go:260	ベンチマーク走行時間: 1m0.233452697s
2024-11-28T15:10:23.197Z	info	isupipe-benchmarker	ベンチマーク走行終了
2024-11-28T15:10:23.197Z	info	isupipe-benchmarker	最終チェックを実施します
2024-11-28T15:10:23.197Z	info	isupipe-benchmarker	最終チェックが成功しました
2024-11-28T15:10:23.197Z	info	isupipe-benchmarker	重複排除したログを以下に出力します
2024-11-28T15:10:23.197Z	info	staff-logger	bench/bench.go:277	ベンチエラーを収集します
2024-11-28T15:10:23.197Z	info	staff-logger	bench/bench.go:285	内部エラーを収集します
2024-11-28T15:10:23.197Z	info	staff-logger	bench/bench.go:301	シナリオカウンタを出力します
2024-11-28T15:10:23.197Z	info	isupipe-benchmarker	配信を最後まで視聴できた視聴者数	{"viewers": 6}
2024-11-28T15:10:23.197Z	info	staff-logger	bench/bench.go:323	[シナリオ aggressive-streamer-moderate] 9 回成功
2024-11-28T15:10:23.198Z	info	staff-logger	bench/bench.go:323	[シナリオ dns-watertorture-attack] 4 回成功
2024-11-28T15:10:23.198Z	info	staff-logger	bench/bench.go:323	[シナリオ streamer-cold-reserve] 27 回成功
2024-11-28T15:10:23.198Z	info	staff-logger	bench/bench.go:323	[シナリオ streamer-moderate] 13 回成功
2024-11-28T15:10:23.198Z	info	staff-logger	bench/bench.go:323	[シナリオ viewer-report] 26 回成功, 1 回失敗
2024-11-28T15:10:23.198Z	info	staff-logger	bench/bench.go:323	[シナリオ viewer-spam] 11 回成功
2024-11-28T15:10:23.198Z	info	staff-logger	bench/bench.go:323	[シナリオ viewer] 6 回成功
2024-11-28T15:10:23.198Z	info	staff-logger	bench/bench.go:323	[失敗シナリオ viewer-report-fail] 1 回失敗
2024-11-28T15:10:23.198Z	info	staff-logger	bench/bench.go:329	DNSAttacker並列数: 2
2024-11-28T15:10:23.198Z	info	staff-logger	bench/bench.go:330	名前解決成功数: 822
2024-11-28T15:10:23.198Z	info	staff-logger	bench/bench.go:331	名前解決失敗数: 0
2024-11-28T15:10:23.198Z	info	staff-logger	bench/bench.go:335	スコア: 2302
```

### スロークエリ

```
make slowq
sudo pt-query-digest /var/log/mysql/mysql-slow.log > /home/isucon/log/mysql-slow.log-2024-11-28-15-11-11
sudo rm /var/log/mysql/mysql-slow.log
cat /home/isucon/log/mysql-slow.log-2024-11-28-15-11-11

# 20s user time, 110ms system time, 35.82M rss, 42.25M vsz
# Current date: Thu Nov 28 15:11:31 2024
# Hostname: ip-172-31-32-187
# Files: /var/log/mysql/mysql-slow.log
# Overall: 269.04k total, 94 unique, 2.34k QPS, 3.40x concurrency ________
# Time range: 2024-11-28T15:08:28 to 2024-11-28T15:10:23
# Attribute          total     min     max     avg     95%  stddev  median
# ============     ======= ======= ======= ======= ======= ======= =======
# Exec time           391s     1us   955ms     1ms     6ms     8ms    60us
# Lock time          537ms       0    43ms     1us     1us   165us       0
# Rows sent        111.88k       0   7.32k    0.43    0.99   21.57       0
# Rows examine      40.80M       0  14.01k  159.03 1012.63  623.28       0
# Query size        23.82M       5   1.94M   92.85  143.84   4.20k   31.70

# Profile
# Rank Query ID                            Response time Calls  R/Call V/M
# ==== =================================== ============= ====== ====== ===
#    1 0xDA556F9115773A1A99AA0165670CE848  54.9639 14.1%  81653 0.0007  0.04 ADMIN PREPARE
#    2 0x42EF7D7D98FBCC9723BF896EBFC51D24  54.0106 13.8%   2432 0.0222  0.01 SELECT records
#    3 0x3D83BC87F3B3A00D571FFC8104A6E50C  33.7463  8.6%   1850 0.0182  0.01 SELECT records
#    4 0xDB74D52D39A7090F224C4DEEAF3028C9  27.0508  6.9%   2370 0.0114  0.05 SELECT users livestreams reactions
#    5 0xF1B8EF06D6CA63B24BFF433E06CCEB22  25.2603  6.5%   2368 0.0107  0.05 SELECT users livestreams livecomments
#    6 0x38BC86A45F31C6B1EE324671506C898A  23.5080  6.0%   5437 0.0043  0.01 SELECT themes
#    7 0x84B457C910C4A79FC9EBECB8B1065C66  17.0224  4.4%   6521 0.0026  0.01 SELECT icons
#    8 0x59F1B6DD8D9FEC059E55B3BFD624E8C3  16.6221  4.3%    337 0.0493  0.01 SELECT reservation_slots
#    9 0x64CC8A4E8E4B390203375597CE4D611F  15.4929  4.0%    129 0.1201  0.02 SELECT ng_words
#   10 0x4ADE2DC90689F1C4891749AF54FB8D14  12.4179  3.2%   7509 0.0017  0.01 DELETE SELECT livecomments
#   11 0xFBC5564AE716EAE82F20BFB45F6C37E7  11.2649  2.9%  11591 0.0010  0.01 SELECT tags
#   12 0xFFFCA4D67EA0A788813031B8BBC3B329  11.0460  2.8%   1103 0.0100  0.01 COMMIT
#   13 0x22279D81D51006139E0C76405B54C261   7.7322  2.0%   2878 0.0027  0.01 SELECT domains domainmetadata
#   14 0xDFFCC1D78939C4D781C7C58349101F50   7.3149  1.9%   1000 0.0073  0.00 INSERT users
#   15 0xD2A0864774622BA36F6557496405CF75   7.1866  1.8%   1077 0.0067  0.00 INSERT themes
#   16 0x8F7679D452333ED3C7D60D22131CEFD4   6.8361  1.7%   8768 0.0008  0.01 ADMIN RESET STMT
#   17 0xEA1E6309EEEFF9A6831AD2FB940FC23C   5.5193  1.4%   5357 0.0010  0.01 SELECT users
#   18 0xA3401CA3ABCC04C3AB221DB8AD5CBF26   5.2053  1.3%     53 0.0982  0.09 UPDATE reservation_slots
#   19 0xFD38427AE3D09E3883A680F7BAF95D3A   5.1681  1.3%  14992 0.0003  0.00 SELECT livestreams livecomments
#   20 0x7F9C0C0BA9473953B723EE16C08655F1   4.9670  1.3%     55 0.0903  0.08 SELECT reservation_slots
# MISC 0xMISC                              38.7667  9.9% 111560 0.0003   0.0 <74 ITEMS>

# Query 1: 770.31 QPS, 0.52x concurrency, ID 0xDA556F9115773A1A99AA0165670CE848 at byte 43146912
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.04
# Time range: 2024-11-28T15:08:37 to 2024-11-28T15:10:23
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count         30   81653
# Exec time     14     55s    15us   955ms   673us     3ms     5ms    63us
# Lock time      0    34us       0    21us       0       0       0       0
# Rows sent      0       0       0       0       0       0       0       0
# Rows examine   0       0       0       0       0       0       0       0
# Query size     9   2.34M      30      30      30      30       0      30
# String:
# Databases    isupipe (81178/99%), isudns (475/0%)
# Hosts        localhost
# Users        isucon (81178/99%), isudns (475/0%)
# Query_time distribution
#   1us
#  10us  ################################################################
# 100us  ##########
#   1ms  ########
#  10ms  #
# 100ms  #
#    1s
#  10s+
administrator command: Prepare\G

# Query 2: 22.94 QPS, 0.51x concurrency, ID 0x42EF7D7D98FBCC9723BF896EBFC51D24 at byte 45862226
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.01
# Time range: 2024-11-28T15:08:37 to 2024-11-28T15:10:23
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          0    2432
# Exec time     13     54s   583us   111ms    22ms    51ms    16ms    20ms
# Lock time      6    36ms     1us    17ms    14us     2us   380us     1us
# Rows sent      0     642       0       1    0.26    0.99    0.44       0
# Rows examine   7   3.07M   1.25k   1.33k   1.29k   1.26k   18.63   1.26k
# Query size     1 339.38k     131     206  142.89  158.58   10.58  136.99
# String:
# Databases    isudns
# Hosts        localhost
# Users        isudns
# Query_time distribution
#   1us
#  10us
# 100us  ######
#   1ms  #############
#  10ms  ################################################################
# 100ms  #
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isudns` LIKE 'records'\G
#    SHOW CREATE TABLE `isudns`.`records`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT content,ttl,prio,type,domain_id,disabled,name,auth FROM records WHERE disabled=0 and name='ri70ekddi83r5p4g0ajquqs433wze0.u.isucon.local' and domain_id=1\G

# Query 3: 17.62 QPS, 0.32x concurrency, ID 0x3D83BC87F3B3A00D571FFC8104A6E50C at byte 49345674
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.01
# Time range: 2024-11-28T15:08:37 to 2024-11-28T15:10:22
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          0    1850
# Exec time      8     34s   580us   116ms    18ms    46ms    15ms    15ms
# Lock time      4    26ms     1us    16ms    14us     2us   365us     1us
# Rows sent      0     958       0       1    0.52    0.99    0.50    0.99
# Rows examine   5   2.33M   1.25k   1.33k   1.29k   1.26k   19.77   1.26k
# Query size     1 246.56k     128     205  136.47  158.58   11.46  124.25
# String:
# Databases    isudns
# Hosts        localhost
# Users        isudns
# Query_time distribution
#   1us
#  10us
# 100us  ##########
#   1ms  ######################
#  10ms  ################################################################
# 100ms  #
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isudns` LIKE 'records'\G
#    SHOW CREATE TABLE `isudns`.`records`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT content,ttl,prio,type,domain_id,disabled,name,auth FROM records WHERE disabled=0 and type='SOA' and name='iyamamoto1.u.isucon.local'\G

# Query 4: 27.24 QPS, 0.31x concurrency, ID 0xDB74D52D39A7090F224C4DEEAF3028C9 at byte 71915761
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.05
# Time range: 2024-11-28T15:08:55 to 2024-11-28T15:10:22
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          0    2370
# Exec time      6     27s     1ms   170ms    11ms    71ms    25ms     1ms
# Lock time      0     5ms     1us   622us     2us     1us    18us     1us
# Rows sent      2   2.31k       1       1       1       1       0       1
# Rows examine  11   4.59M   1.96k   2.15k   1.98k   2.06k   69.34   1.96k
# Query size     1 335.07k     143     146  144.77  143.84    0.93  143.84
# String:
# Databases    isupipe
# Hosts        localhost
# Users        isucon
# Query_time distribution
#   1us
#  10us
# 100us
#   1ms  ################################################################
#  10ms  ##########
# 100ms  #
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isupipe` LIKE 'users'\G
#    SHOW CREATE TABLE `isupipe`.`users`\G
#    SHOW TABLE STATUS FROM `isupipe` LIKE 'livestreams'\G
#    SHOW CREATE TABLE `isupipe`.`livestreams`\G
#    SHOW TABLE STATUS FROM `isupipe` LIKE 'reactions'\G
#    SHOW CREATE TABLE `isupipe`.`reactions`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT COUNT(*) FROM users u
		INNER JOIN livestreams l ON l.user_id = u.id
		INNER JOIN reactions r ON r.livestream_id = l.id
		WHERE u.id = 48\G

# Query 5: 27.22 QPS, 0.29x concurrency, ID 0xF1B8EF06D6CA63B24BFF433E06CCEB22 at byte 67469380
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.05
# Time range: 2024-11-28T15:08:55 to 2024-11-28T15:10:22
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          0    2368
# Exec time      6     25s     1ms   142ms    11ms    65ms    23ms     2ms
# Lock time      3    19ms     1us    11ms     8us     1us   233us     1us
# Rows sent      2   2.31k       1       1       1       1       0       1
# Rows examine  11   4.58M   1.96k   2.14k   1.98k   2.06k   69.28   1.96k
# Query size     1 381.04k     163     166  164.77  158.58       0  158.58
# String:
# Databases    isupipe
# Hosts        localhost
# Users        isucon
# Query_time distribution
#   1us
#  10us
# 100us
#   1ms  ################################################################
#  10ms  ##########
# 100ms  #
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isupipe` LIKE 'users'\G
#    SHOW CREATE TABLE `isupipe`.`users`\G
#    SHOW TABLE STATUS FROM `isupipe` LIKE 'livestreams'\G
#    SHOW CREATE TABLE `isupipe`.`livestreams`\G
#    SHOW TABLE STATUS FROM `isupipe` LIKE 'livecomments'\G
#    SHOW CREATE TABLE `isupipe`.`livecomments`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT IFNULL(SUM(l2.tip), 0) FROM users u
		INNER JOIN livestreams l ON l.user_id = u.id	
		INNER JOIN livecomments l2 ON l2.livestream_id = l.id
		WHERE u.id = 1\G

# Query 6: 62.49 QPS, 0.27x concurrency, ID 0x38BC86A45F31C6B1EE324671506C898A at byte 65674305
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.01
# Time range: 2024-11-28T15:08:55 to 2024-11-28T15:10:22
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          2    5437
# Exec time      6     24s   190us    86ms     4ms    19ms     8ms   725us
# Lock time      6    33ms       0    19ms     6us     1us   249us     1us
# Rows sent      4   5.31k       1       1       1       1       0       1
# Rows examine  13   5.37M    1000   1.05k   1.01k   1.04k   32.43 1012.63
# Query size     0 215.89k      38      41   40.66   40.45    0.91   40.45
# String:
# Databases    isupipe
# Hosts        localhost
# Users        isucon
# Query_time distribution
#   1us
#  10us
# 100us  ################################################################
#   1ms  ###########################################
#  10ms  ##############
# 100ms
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isupipe` LIKE 'themes'\G
#    SHOW CREATE TABLE `isupipe`.`themes`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT * FROM themes WHERE user_id = 1019\G

# Query 7: 74.95 QPS, 0.20x concurrency, ID 0x84B457C910C4A79FC9EBECB8B1065C66 at byte 61704918
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.01
# Time range: 2024-11-28T15:08:55 to 2024-11-28T15:10:22
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          2    6521
# Exec time      4     17s    43us    75ms     3ms    12ms     6ms   384us
# Lock time      5    29ms       0     3ms     4us     1us    74us     1us
# Rows sent      3   4.04k       0       1    0.63    0.99    0.48    0.99
# Rows examine   0   4.04k       0       1    0.63    0.99    0.48    0.99
# Query size     1 277.99k      41      44   43.65   42.48    0.37   42.48
# String:
# Databases    isupipe
# Hosts        localhost
# Users        isucon
# Query_time distribution
#   1us
#  10us  ###################
# 100us  ################################################################
#   1ms  #############################################
#  10ms  ########
# 100ms
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isupipe` LIKE 'icons'\G
#    SHOW CREATE TABLE `isupipe`.`icons`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT image FROM icons WHERE user_id = 1026\G

# Query 8: 3.92 QPS, 0.19x concurrency, ID 0x59F1B6DD8D9FEC059E55B3BFD624E8C3 at byte 55715751
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.01
# Time range: 2024-11-28T15:08:55 to 2024-11-28T15:10:21
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          0     337
# Exec time      4     17s     2ms   149ms    49ms    95ms    27ms    48ms
# Lock time      0     1ms     1us     1ms     4us     1us    52us     1us
# Rows sent      0     337       1       1       1       1       0       1
# Rows examine   6   2.82M   8.55k   8.55k   8.55k   8.55k       0   8.55k
# Query size     0  28.30k      86      86      86      86       0      86
# String:
# Databases    isupipe
# Hosts        localhost
# Users        isucon
# Query_time distribution
#   1us
#  10us
# 100us
#   1ms  #######
#  10ms  ################################################################
# 100ms  ####
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isupipe` LIKE 'reservation_slots'\G
#    SHOW CREATE TABLE `isupipe`.`reservation_slots`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT slot FROM reservation_slots WHERE start_at = 1700982000 AND end_at = 1700985600\G

# Query 9: 1.65 QPS, 0.20x concurrency, ID 0x64CC8A4E8E4B390203375597CE4D611F at byte 49526290
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.02
# Time range: 2024-11-28T15:09:04 to 2024-11-28T15:10:22
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          0     129
# Exec time      3     15s     4ms   239ms   120ms   180ms    48ms   128ms
# Lock time      0   182us     1us    12us     1us     1us     1us     1us
# Rows sent      0       8       0       1    0.06    0.99    0.24       0
# Rows examine   4   1.76M  14.00k  14.01k  14.00k  13.78k       0  13.78k
# Query size     0  12.47k      97      99   98.97   97.36    0.57   97.36
# String:
# Databases    isupipe
# Hosts        localhost
# Users        isucon
# Query_time distribution
#   1us
#  10us
# 100us
#   1ms  ######
#  10ms  ##########
# 100ms  ################################################################
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isupipe` LIKE 'ng_words'\G
#    SHOW CREATE TABLE `isupipe`.`ng_words`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT id, user_id, livestream_id, word FROM ng_words WHERE user_id = 1019 AND livestream_id = 7528\G

# Query 10: 125.15 QPS, 0.21x concurrency, ID 0x4ADE2DC90689F1C4891749AF54FB8D14 at byte 53399665
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.01
# Time range: 2024-11-28T15:09:22 to 2024-11-28T15:10:22
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          2    7509
# Exec time      3     12s    38us    56ms     2ms     7ms     4ms   113us
# Lock time     13    70ms       0    35ms     9us     1us   470us     1us
# Rows sent      0       0       0       0       0       0       0       0
# Rows examine   0  14.67k       2       4    2.00    1.96    0.04    1.96
# Query size    10   2.38M     269     502  332.73  381.65   25.54  313.99
# String:
# Databases    isupipe
# Hosts        localhost
# Users        isucon
# Query_time distribution
#   1us
#  10us  ################################################################
# 100us  ##########################################################
#   1ms  #########################################
#  10ms  ######
# 100ms
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isupipe` LIKE 'livecomments'\G
#    SHOW CREATE TABLE `isupipe`.`livecomments`\G
DELETE FROM livecomments
			WHERE
			id = 161 AND
			livestream_id = 7527 AND
			(SELECT COUNT(*)
			FROM
			(SELECT 'その戦術、ちょっと古いかな。もっと新しい情報を入手して欲しいな。' AS text) AS texts
			INNER JOIN
			(SELECT CONCAT('%', '虹龍結界', '%')	AS pattern) AS patterns
			ON texts.text LIKE patterns.pattern) >= 1\G
# Converted for EXPLAIN
# EXPLAIN /*!50100 PARTITIONS*/
select * from  livecomments
			WHERE
			id = 161 AND
			livestream_id = 7527 AND
			(SELECT COUNT(*)
			FROM
			(SELECT 'その戦術、ちょっと古いかな。もっと新しい情報を入手して欲しいな。' AS text) AS texts
			INNER JOIN
			(SELECT CONCAT('%', '虹龍結界', '%')	AS pattern) AS patterns
			ON texts.text LIKE patterns.pattern) >= 1\G

# Query 11: 170.46 QPS, 0.17x concurrency, ID 0xFBC5564AE716EAE82F20BFB45F6C37E7 at byte 67728957
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.01
# Time range: 2024-11-28T15:09:14 to 2024-11-28T15:10:22
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          4   11591
# Exec time      2     11s    25us    67ms   971us     4ms     3ms    89us
# Lock time     10    56ms       0    14ms     4us     1us   167us     1us
# Rows sent     10  11.32k       1       1       1       1       0       1
# Rows examine   0  11.32k       1       1       1       1       0       1
# Query size     1 361.19k      31      33   31.91   31.70    0.53   31.70
# String:
# Databases    isupipe
# Hosts        localhost
# Users        isucon
# Query_time distribution
#   1us
#  10us  ################################################################
# 100us  ##########################
#   1ms  ##################
#  10ms  ##
# 100ms
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isupipe` LIKE 'tags'\G
#    SHOW CREATE TABLE `isupipe`.`tags`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT * FROM tags WHERE id = 30\G

# Query 12: 12.53 QPS, 0.13x concurrency, ID 0xFFFCA4D67EA0A788813031B8BBC3B329 at byte 60916236
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.01
# Time range: 2024-11-28T15:08:55 to 2024-11-28T15:10:23
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          0    1103
# Exec time      2     11s    21us    62ms    10ms    30ms    11ms     5ms
# Lock time      0       0       0       0       0       0       0       0
# Rows sent      0       0       0       0       0       0       0       0
# Rows examine   0       0       0       0       0       0       0       0
# Query size     0   6.46k       6       6       6       6       0       6
# String:
# Databases    isupipe (1025/92%), isudns (78/7%)
# Hosts        localhost
# Users        isucon (1025/92%), isudns (78/7%)
# Query_time distribution
#   1us
#  10us  #######################
# 100us  #####################
#   1ms  #################################
#  10ms  ################################################################
# 100ms
#    1s
#  10s+
COMMIT\G

# Query 13: 27.15 QPS, 0.07x concurrency, ID 0x22279D81D51006139E0C76405B54C261 at byte 58456174
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.01
# Time range: 2024-11-28T15:08:37 to 2024-11-28T15:10:23
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          1    2878
# Exec time      1      8s    65us    74ms     3ms    14ms     6ms   316us
# Lock time      3    18ms     1us     3ms     6us     2us    88us     1us
# Rows sent      0       0       0       0       0       0       0       0
# Rows examine   0       0       0       0       0       0       0       0
# Query size     1 326.02k     116     116     116     116       0     116
# String:
# Databases    isudns
# Hosts        localhost
# Users        isudns
# Query_time distribution
#   1us
#  10us  #
# 100us  ################################################################
#   1ms  ################################
#  10ms  ########
# 100ms
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isudns` LIKE 'domains'\G
#    SHOW CREATE TABLE `isudns`.`domains`\G
#    SHOW TABLE STATUS FROM `isudns` LIKE 'domainmetadata'\G
#    SHOW CREATE TABLE `isudns`.`domainmetadata`\G
# EXPLAIN /*!50100 PARTITIONS*/
select kind,content from domains, domainmetadata where domainmetadata.domain_id=domains.id and name='u.isucon.local'\G

# Query 14: 66.67 QPS, 0.49x concurrency, ID 0xDFFCC1D78939C4D781C7C58349101F50 at byte 571356
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.00
# Time range: 2024-11-28T15:08:37 to 2024-11-28T15:08:52
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          0    1000
# Exec time      1      7s     4ms    26ms     7ms    10ms     1ms     7ms
# Lock time      0     2ms     1us    24us     2us     2us     1us     1us
# Rows sent      0       0       0       0       0       0       0       0
# Rows examine   0       0       0       0       0       0       0       0
# Query size     1 401.18k     192     463  410.81  420.77   16.87  400.73
# String:
# Databases    isupipe
# Hosts        localhost
# Users        isucon
# Query_time distribution
#   1us
#  10us
# 100us
#   1ms  ################################################################
#  10ms  ###
# 100ms
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isupipe` LIKE 'users'\G
#    SHOW CREATE TABLE `isupipe`.`users`\G
INSERT INTO users (id, name, display_name, description, password) VALUES (646, 'hiroshiendo0', '感慨', '普段営業をしています。\nよろしくおねがいします！\n\n連絡は以下からお願いします。\n\nウェブサイト: http://hiroshiendo.example.com/\nメールアドレス: hiroshiendo@example.com\n', '$2a$04$UwZb6IFm4tgS1pLvujdaV.sK3Gq9zN2IJyIuGjqtMyuSL/dZXfqjK')\G

# Query 15: 10.36 QPS, 0.07x concurrency, ID 0xD2A0864774622BA36F6557496405CF75 at byte 74723904
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.00
# Time range: 2024-11-28T15:08:38 to 2024-11-28T15:10:22
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          0    1077
# Exec time      1      7s    55us    46ms     7ms     8ms     2ms     7ms
# Lock time      0     2ms     1us    18us     2us     2us     1us     1us
# Rows sent      0       0       0       0       0       0       0       0
# Rows examine   0       0       0       0       0       0       0       0
# Query size     0  61.15k      55      60   58.14   56.92    0.72   56.92
# String:
# Databases    isupipe
# Hosts        localhost
# Users        isucon
# Query_time distribution
#   1us
#  10us  #
# 100us  #
#   1ms  ################################################################
#  10ms  #
# 100ms
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isupipe` LIKE 'themes'\G
#    SHOW CREATE TABLE `isupipe`.`themes`\G
INSERT INTO themes (user_id, dark_mode) VALUES(1072, 1)\G

# Query 16: 82.72 QPS, 0.06x concurrency, ID 0x8F7679D452333ED3C7D60D22131CEFD4 at byte 50591747
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.01
# Time range: 2024-11-28T15:08:37 to 2024-11-28T15:10:23
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          3    8768
# Exec time      1      7s     6us    55ms   779us     4ms     3ms    47us
# Lock time      0       0       0       0       0       0       0       0
# Rows sent      0       0       0       0       0       0       0       0
# Rows examine   0       0       0       0       0       0       0       0
# Query size     1 282.56k      33      33      33      33       0      33
# String:
# Databases    isudns
# Hosts        localhost
# Users        isudns
# Query_time distribution
#   1us  ########
#  10us  ################################################################
# 100us  ##############
#   1ms  #############
#  10ms  ##
# 100ms
#    1s
#  10s+
administrator command: Reset stmt\G

# Query 17: 61.57 QPS, 0.06x concurrency, ID 0xEA1E6309EEEFF9A6831AD2FB940FC23C at byte 48091971
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.01
# Time range: 2024-11-28T15:08:55 to 2024-11-28T15:10:22
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          1    5357
# Exec time      1      6s    33us    71ms     1ms     4ms     4ms    98us
# Lock time      4    25ms       0    12ms     4us     1us   163us     1us
# Rows sent      4   5.23k       1       1       1       1       0       1
# Rows examine   0   5.23k       1       1       1       1       0       1
# Query size     0 181.30k      32      35   34.66   34.95    0.89   34.95
# String:
# Databases    isupipe
# Hosts        localhost
# Users        isucon
# Query_time distribution
#   1us
#  10us  ################################################################
# 100us  #########################################
#   1ms  ####################
#  10ms  ##
# 100ms
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isupipe` LIKE 'users'\G
#    SHOW CREATE TABLE `isupipe`.`users`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT * FROM users WHERE id = 31\G

# Query 18: 0.62 QPS, 0.06x concurrency, ID 0xA3401CA3ABCC04C3AB221DB8AD5CBF26 at byte 78826503
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.09
# Time range: 2024-11-28T15:08:55 to 2024-11-28T15:10:21
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          0      53
# Exec time      1      5s     6ms   262ms    98ms   219ms    93ms    74ms
# Lock time      0   463us     1us   395us     8us     1us    52us     1us
# Rows sent      0       0       0       0       0       0       0       0
# Rows examine   1 453.35k   8.55k   8.55k   8.55k   8.55k       0   8.55k
# Query size     0   5.07k      98      98      98      98       0      98
# String:
# Databases    isupipe
# Hosts        localhost
# Users        isucon
# Query_time distribution
#   1us
#  10us
# 100us
#   1ms  ################################################################
#  10ms  ####
# 100ms  #############################################################
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isupipe` LIKE 'reservation_slots'\G
#    SHOW CREATE TABLE `isupipe`.`reservation_slots`\G
UPDATE reservation_slots SET slot = slot - 1 WHERE start_at >= 1701108000 AND end_at <= 1701140400\G
# Converted for EXPLAIN
# EXPLAIN /*!50100 PARTITIONS*/
select  slot = slot - 1 from reservation_slots where  start_at >= 1701108000 AND end_at <= 1701140400\G

# Query 19: 937 QPS, 0.32x concurrency, ID 0xFD38427AE3D09E3883A680F7BAF95D3A at byte 29571057
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.00
# Time range: 2024-11-28T15:08:58 to 2024-11-28T15:09:14
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          5   14992
# Exec time      1      5s   200us     5ms   344us   725us   223us   260us
# Lock time      3    21ms     1us     1ms     1us     1us    11us     1us
# Rows sent     13  14.64k       1       1       1       1       0       1
# Rows examine  35  14.33M    1001    1003    1002  964.41       0  964.41
# Query size     7   1.71M     117     120  119.85  118.34    0.64  118.34
# String:
# Databases    isupipe
# Hosts        localhost
# Users        isucon
# Query_time distribution
#   1us
#  10us
# 100us  ################################################################
#   1ms  ##
#  10ms
# 100ms
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isupipe` LIKE 'livestreams'\G
#    SHOW CREATE TABLE `isupipe`.`livestreams`\G
#    SHOW TABLE STATUS FROM `isupipe` LIKE 'livecomments'\G
#    SHOW CREATE TABLE `isupipe`.`livecomments`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT IFNULL(SUM(l2.tip), 0) FROM livestreams l INNER JOIN livecomments l2 ON l.id = l2.livestream_id WHERE l.id = 5830\G

# Query 20: 0.62 QPS, 0.06x concurrency, ID 0x7F9C0C0BA9473953B723EE16C08655F1 at byte 73993656
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.08
# Time range: 2024-11-28T15:08:55 to 2024-11-28T15:10:23
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          0      55
# Exec time      1      5s     5ms   274ms    90ms   219ms    86ms   103ms
# Lock time      0    85us     1us    13us     1us     1us     1us     1us
# Rows sent      0     343       1      20    6.24   18.53    6.30    2.90
# Rows examine   1 470.45k   8.55k   8.55k   8.55k   8.55k       0   8.55k
# Query size     0   5.16k      96      96      96      96       0      96
# String:
# Databases    isupipe
# Hosts        localhost
# Users        isucon
# Query_time distribution
#   1us
#  10us
# 100us
#   1ms  #############################################################
#  10ms
# 100ms  ################################################################
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isupipe` LIKE 'reservation_slots'\G
#    SHOW CREATE TABLE `isupipe`.`reservation_slots`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT * FROM reservation_slots WHERE start_at >= 1701097200 AND end_at <= 1701118800 FOR UPDATE\G
```

### アクセスログ

```
+-------+-----+--------+--------------------------------------------------------------------------------------------+--------+--------+---------+--------+--------+
| COUNT | 5XX | METHOD |                                            URI                                             |  MIN   |  MAX   |   SUM   |  AVG   |  P99   |
+-------+-----+--------+--------------------------------------------------------------------------------------------+--------+--------+---------+--------+--------+
| 1090  | 0   | GET    | /api/user/.+/icon                                                                          | 0.001  | 1.413  | 153.505 | 0.141  | 0.907  |
| 127   | 0   | GET    | /api/livestream/\d+/livecomment                                                            | 0.001  | 2.402  | 98.328  | 0.774  | 2.073  |
| 162   | 0   | GET    | /api/livestream/\d+/reaction                                                               | 0.004  | 2.304  | 87.724  | 0.542  | 2.015  |
| 9     | 0   | POST   | /api/livestream/\d+/moderate                                                               | 0.045  | 14.381 | 80.482  | 8.942  | 14.381 |
| 159   | 0   | POST   | /api/livestream/\d+/livecomment                                                            | 0.007  | 1.504  | 65.867  | 0.414  | 1.400  |
| 5     | 0   | GET    | /api/user/.+/statistics                                                                    | 3.304  | 19.999 | 65.653  | 13.131 | 19.999 |
| 19    | 0   | GET    | /api/livestream/search?limit=50                                                            | 0.077  | 5.556  | 56.561  | 2.977  | 5.556  |
| 80    | 1   | POST   | /api/register                                                                              | 0.001  | 3.181  | 54.563  | 0.682  | 3.181  |
| 57    | 0   | POST   | /api/livestream/reservation                                                                | 0.001  | 2.498  | 41.430  | 0.727  | 2.498  |
| 128   | 0   | POST   | /api/livestream/\d+/reaction                                                               | 0.006  | 1.143  | 29.625  | 0.231  | 0.973  |
| 1     | 0   | POST   | /api/initialize                                                                            | 18.156 | 18.156 | 18.156  | 18.156 | 18.156 |
| 74    | 0   | POST   | /api/icon                                                                                  | 0.018  | 0.966  | 17.188  | 0.232  | 0.966  |
| 2     | 0   | GET    | /api/livestream/search?tag=%E3%83%A9%E3%82%A4%E3%83%95%E3%83%8F%E3%83%83%E3%82%AF          | 6.980  | 6.989  | 13.969  | 6.985  | 6.989  |
| 84    | 0   | POST   | /api/login                                                                                 | 0.002  | 1.687  | 12.808  | 0.152  | 1.687  |
| 2     | 0   | GET    | /api/livestream/\d+/statistics                                                             | 5.962  | 6.078  | 12.040  | 6.020  | 6.078  |
| 1     | 0   | GET    | /api/livestream/search?tag=%E9%87%A3%E3%82%8A                                              | 7.644  | 7.644  | 7.644   | 7.644  | 7.644  |
| 30    | 0   | GET    | /api/livestream                                                                            | 0.018  | 0.903  | 7.603   | 0.253  | 0.903  |
| 21    | 0   | GET    | /api/livestream/\d+/report                                                                 | 0.002  | 1.956  | 6.359   | 0.303  | 1.956  |
| 35    | 0   | GET    | /api/tag                                                                                   | 0.001  | 1.030  | 4.724   | 0.135  | 1.030  |
| 14    | 0   | GET    | /api/livestream/\d+/ngwords                                                                | 0.009  | 0.771  | 4.145   | 0.296  | 0.771  |
| 1     | 0   | GET    | /api/livestream/search?tag=%E5%BF%83%E7%90%86%E5%AD%A6                                     | 2.241  | 2.241  | 2.241   | 2.241  | 2.241  |
| 16    | 0   | POST   | /api/livestream/\d+/enter                                                                  | 0.006  | 0.967  | 1.908   | 0.119  | 0.967  |
| 7     | 0   | DELETE | /api/livestream/\d+/exit                                                                   | 0.006  | 0.454  | 1.151   | 0.164  | 0.454  |
| 1     | 0   | GET    | /api/livestream/search?tag=%E4%B8%8D%E5%8B%95%E7%94%A3                                     | 0.237  | 0.237  | 0.237   | 0.237  | 0.237  |
| 1     | 0   | GET    | /api/livestream/search?tag=%E3%83%A9%E3%82%A4%E3%83%96%E9%85%8D%E4%BF%A1                   | 0.235  | 0.235  | 0.235   | 0.235  | 0.235  |
| 1     | 0   | GET    | /api/livestream/search?tag=%E6%A4%85%E5%AD%90                                              | 0.230  | 0.230  | 0.230   | 0.230  | 0.230  |
| 1     | 0   | GET    | /api/livestream/search?tag=%E7%8C%AB                                                       | 0.228  | 0.228  | 0.228   | 0.228  | 0.228  |
| 1     | 0   | GET    | /api/livestream/search?tag=%E3%82%A2%E3%83%8B%E3%83%A1%E3%83%88%E3%83%BC%E3%82%AF          | 0.212  | 0.212  | 0.212   | 0.212  | 0.212  |
| 4     | 0   | GET    | /api/user/.+/theme                                                                         | 0.002  | 0.075  | 0.208   | 0.052  | 0.075  |
| 1     | 0   | GET    | /api/livestream/search?tag=%E6%96%B0%E4%BD%9C%E3%82%B2%E3%83%BC%E3%83%A0                   | 0.208  | 0.208  | 0.208   | 0.208  | 0.208  |
| 1     | 0   | GET    | /api/livestream/search?tag=%E3%82%B2%E3%83%BC%E3%83%A0%E5%AE%9F%E6%B3%81                   | 0.204  | 0.204  | 0.204   | 0.204  | 0.204  |
| 1     | 0   | GET    | /api/livestream/search?tag=%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E7%94%9F%E6%94%BE%E9%80%81 | 0.204  | 0.204  | 0.204   | 0.204  | 0.204  |
| 1     | 0   | GET    | /api/livestream/search?tag=%E3%83%97%E3%83%AD%E3%82%B2%E3%83%BC%E3%83%9E%E3%83%BC          | 0.198  | 0.198  | 0.198   | 0.198  | 0.198  |
| 3     | 0   | GET    | /api/user/me                                                                               | 0.002  | 0.006  | 0.012   | 0.004  | 0.006  |
| 1     | 0   | GET    | /api/livestream/\d+                                                                        | 0.006  | 0.006  | 0.006   | 0.006  | 0.006  |
| 1     | 0   | GET    | /api/payment                                                                               | 0.003  | 0.003  | 0.003   | 0.003  | 0.003  |
| 1     | 0   | GET    | /api/user/test                                                                             | 0.001  | 0.001  | 0.001   | 0.001  | 0.001  |
+-------+-----+--------+--------------------------------------------------------------------------------------------+--------+--------+---------+--------+--------+
```