### PR TITLE
use cache for icon

### DIFF
--- a/webapp/go/go.mod
+++ b/webapp/go/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/newrelic/go-agent/v3 v3.35.0 // indirect
 	github.com/newrelic/go-agent/v3/integrations/nrecho-v4 v1.1.2 // indirect
+	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
 	golang.org/x/net v0.30.0 // indirect

--- a/webapp/go/go.sum
+++ b/webapp/go/go.sum
@@ -51,6 +51,8 @@ github.com/newrelic/go-agent/v3 v3.35.0 h1:YIG6mhwzIEBaaG3YmxPHgBfBFmHNoChxbKYH5
 github.com/newrelic/go-agent/v3 v3.35.0/go.mod h1:GNTda53CohAhkgsc7/gqSsJhDZjj8vaky5u+vKz7wqM=
 github.com/newrelic/go-agent/v3/integrations/nrecho-v4 v1.1.2 h1:eGz53UYAOJJeirioQq0J5V2ZmucZh4o+UGZAs7I5UKM=
 github.com/newrelic/go-agent/v3/integrations/nrecho-v4 v1.1.2/go.mod h1:nSDnTXhoJA7Nb4NO03amTIyr2M57/a79I635hHuqX6c=
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"time"
 
 	"github.com/go-sql-driver/mysql"
 	"github.com/gorilla/sessions"
@@ -23,6 +24,7 @@ import (
 	echolog "github.com/labstack/gommon/log"
 	"github.com/newrelic/go-agent/v3/integrations/nrecho-v4"
 	"github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/patrickmn/go-cache"
 )
 
 const (
@@ -34,6 +36,7 @@ var (
 	powerDNSSubdomainAddress string
 	dbConn                   *sqlx.DB
 	secret                   = []byte("isucon13_session_cookiestore_defaultsecret")
+	gCache                   *cache.Cache
 )
 
 func init() {
@@ -41,6 +44,8 @@ func init() {
 	if secretKey, ok := os.LookupEnv("ISUCON13_SESSION_SECRETKEY"); ok {
 		secret = []byte(secretKey)
 	}
+
+	gCache = cache.New(5*time.Minute, 10*time.Minute)
 }
 
 type InitializeResponse struct {
@@ -122,9 +127,9 @@ func initializeHandler(c echo.Context) error {
 }
 
 func main() {
-	go func() { 
-		log.Println(http.ListenAndServe("localhost:6060", nil)) 
-	}() 
+	go func() {
+		log.Println(http.ListenAndServe("localhost:6060", nil))
+	}()
 
 	err := godotenv.Load()
 	if err != nil {


### PR DESCRIPTION
## 概要

## 実行結果

### ベンチマーク

```

2024-12-02T07:24:22.566Z	warn	staff-logger	scenario/streamer.go:139	streamer_moderate: failed to visit livestream admin: ベンチマーク走行が継続できないエラーが発生しました

2024-12-02T07:24:22.566Z	warn	staff-logger	scenario/viewer.go:78	view: failed to visit user profile: ベンチマーク走行が継続できないエラーが発生しました

2024-12-02T07:24:22.996Z	info	staff-logger	bench/bench.go:260	ベンチマーク走行時間: 1m0.469498297s
2024-12-02T07:24:22.996Z	info	isupipe-benchmarker	ベンチマーク走行終了
2024-12-02T07:24:22.996Z	info	isupipe-benchmarker	最終チェックを実施します
2024-12-02T07:24:22.996Z	info	isupipe-benchmarker	最終チェックが成功しました
2024-12-02T07:24:22.996Z	info	isupipe-benchmarker	重複排除したログを以下に出力します
2024-12-02T07:24:22.996Z	info	staff-logger	bench/bench.go:277	ベンチエラーを収集します
2024-12-02T07:24:22.997Z	info	staff-logger	bench/bench.go:285	内部エラーを収集します
2024-12-02T07:24:22.997Z	info	staff-logger	bench/bench.go:301	シナリオカウンタを出力します
2024-12-02T07:24:22.997Z	info	isupipe-benchmarker	配信を最後まで視聴できた視聴者数	{"viewers": 7}
2024-12-02T07:24:22.997Z	info	staff-logger	bench/bench.go:323	[シナリオ aggressive-streamer-moderate] 7 回成功
2024-12-02T07:24:22.997Z	info	staff-logger	bench/bench.go:323	[シナリオ dns-watertorture-attack] 4 回成功
2024-12-02T07:24:22.997Z	info	staff-logger	bench/bench.go:323	[シナリオ streamer-cold-reserve] 28 回成功
2024-12-02T07:24:22.997Z	info	staff-logger	bench/bench.go:323	[シナリオ streamer-moderate] 16 回成功
2024-12-02T07:24:22.997Z	info	staff-logger	bench/bench.go:323	[シナリオ viewer-report] 26 回成功, 1 回失敗
2024-12-02T07:24:22.997Z	info	staff-logger	bench/bench.go:323	[シナリオ viewer-spam] 9 回成功
2024-12-02T07:24:22.997Z	info	staff-logger	bench/bench.go:323	[シナリオ viewer] 7 回成功
2024-12-02T07:24:22.997Z	info	staff-logger	bench/bench.go:323	[失敗シナリオ viewer-report-fail] 1 回失敗
2024-12-02T07:24:22.997Z	info	staff-logger	bench/bench.go:329	DNSAttacker並列数: 2
2024-12-02T07:24:22.997Z	info	staff-logger	bench/bench.go:330	名前解決成功数: 844
2024-12-02T07:24:22.997Z	info	staff-logger	bench/bench.go:331	名前解決失敗数: 2
2024-12-02T07:24:22.997Z	info	staff-logger	bench/bench.go:335	スコア: 2261
```

### スロークエリ

```
make slowq
sudo pt-query-digest /var/log/mysql/mysql-slow.log > /home/isucon/log/mysql-slow.log-2024-12-02-07-27-26
sudo rm /var/log/mysql/mysql-slow.log
cat /home/isucon/log/mysql-slow.log-2024-12-02-07-27-26

# 19.9s user time, 120ms system time, 36.51M rss, 42.96M vsz
# Current date: Mon Dec  2 07:27:46 2024
# Hostname: ip-172-31-32-187
# Files: /var/log/mysql/mysql-slow.log
# Overall: 269.67k total, 95 unique, 636.01 QPS, 0.91x concurrency _______
# Time range: 2024-12-02T07:17:18 to 2024-12-02T07:24:22
# Attribute          total     min     max     avg     95%  stddev  median
# ============     ======= ======= ======= ======= ======= ======= =======
# Exec time           384s     1us   761ms     1ms     6ms     7ms    63us
# Lock time          968ms       0    59ms     3us     1us   277us       0
# Rows sent        113.02k       0   7.32k    0.43    0.99   21.67       0
# Rows examine      40.93M       0  14.01k  159.14 1012.63  620.79       0
# Query size        24.30M       5   1.94M   94.49  143.84   4.23k   31.70

# Profile
# Rank Query ID                            Response time Calls  R/Call V/M
# ==== =================================== ============= ====== ====== ===
#    1 0xDA556F9115773A1A99AA0165670CE848  53.3549 13.9%  81662 0.0007  0.02 ADMIN PREPARE
#    2 0x42EF7D7D98FBCC9723BF896EBFC51D24  52.1208 13.6%   2527 0.0206  0.01 SELECT records
#    3 0x3D83BC87F3B3A00D571FFC8104A6E50C  33.9512  8.8%   1907 0.0178  0.01 SELECT records
#    4 0xDB74D52D39A7090F224C4DEEAF3028C9  24.7869  6.5%   2358 0.0105  0.05 SELECT users livestreams reactions
#    5 0x38BC86A45F31C6B1EE324671506C898A  22.9972  6.0%   5408 0.0043  0.01 SELECT themes
#    6 0xF1B8EF06D6CA63B24BFF433E06CCEB22  22.4609  5.9%   2355 0.0095  0.05 SELECT users livestreams livecomments
#    7 0x84B457C910C4A79FC9EBECB8B1065C66  17.0271  4.4%   6535 0.0026  0.01 SELECT icons
#    8 0x59F1B6DD8D9FEC059E55B3BFD624E8C3  16.4279  4.3%    343 0.0479  0.01 SELECT reservation_slots
#    9 0x64CC8A4E8E4B390203375597CE4D611F  14.9541  3.9%    123 0.1216  0.02 SELECT ng_words
#   10 0x4ADE2DC90689F1C4891749AF54FB8D14  12.9487  3.4%   7543 0.0017  0.01 DELETE SELECT livecomments
#   11 0xFBC5564AE716EAE82F20BFB45F6C37E7  11.1780  2.9%  11544 0.0010  0.01 SELECT tags
#   12 0xFFFCA4D67EA0A788813031B8BBC3B329  10.5762  2.8%   1101 0.0096  0.01 COMMIT
#   13 0xDFFCC1D78939C4D781C7C58349101F50   7.5221  2.0%   1000 0.0075  0.00 INSERT users
#   14 0x22279D81D51006139E0C76405B54C261   7.4694  1.9%   2972 0.0025  0.01 SELECT domains domainmetadata
#   15 0xD2A0864774622BA36F6557496405CF75   7.3563  1.9%   1081 0.0068  0.00 INSERT themes
#   16 0x8F7679D452333ED3C7D60D22131CEFD4   7.3547  1.9%   9001 0.0008  0.01 ADMIN RESET STMT
#   17 0xFD38427AE3D09E3883A680F7BAF95D3A   5.6801  1.5%  14992 0.0004  0.00 SELECT livestreams livecomments
#   18 0x7F9C0C0BA9473953B723EE16C08655F1   5.4026  1.4%     56 0.0965  0.09 SELECT reservation_slots
#   19 0xA3401CA3ABCC04C3AB221DB8AD5CBF26   5.1796  1.3%     54 0.0959  0.08 UPDATE reservation_slots
#   20 0xEA1E6309EEEFF9A6831AD2FB940FC23C   4.9333  1.3%   5323 0.0009  0.01 SELECT users
# MISC 0xMISC                              40.1067 10.5% 111782 0.0004   0.0 <75 ITEMS>

# Query 1: 192.60 QPS, 0.13x concurrency, ID 0xDA556F9115773A1A99AA0165670CE848 at byte 43306777
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.02
# Time range: 2024-12-02T07:17:18 to 2024-12-02T07:24:22
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count         30   81662
# Exec time     13     53s    14us   761ms   653us     3ms     4ms    63us
# Lock time      0    73us       0    42us       0       0       0       0
# Rows sent      0       0       0       0       0       0       0       0
# Rows examine   0       0       0       0       0       0       0       0
# Query size     9   2.34M      30      30      30      30       0      30
# String:
# Databases    isupipe (81162/99%), isudns (500/0%)
# Hosts        localhost
# Users        isucon (81162/99%), isudns (500/0%)
# Query_time distribution
#   1us
#  10us  ################################################################
# 100us  ###########
#   1ms  ########
#  10ms  #
# 100ms  #
#    1s
#  10s+
administrator command: Prepare\G

# Query 2: 23.40 QPS, 0.48x concurrency, ID 0x42EF7D7D98FBCC9723BF896EBFC51D24 at byte 68203329
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.01
# Time range: 2024-12-02T07:22:34 to 2024-12-02T07:24:22
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          0    2527
# Exec time     13     52s   593us    94ms    21ms    46ms    15ms    18ms
# Lock time      4    42ms     1us    18ms    16us     2us   460us     1us
# Rows sent      0     640       0       1    0.25    0.99    0.43       0
# Rows examine   7   3.19M   1.25k   1.33k   1.29k   1.26k   24.01   1.26k
# Query size     1 352.84k     131     210  142.98  158.58   10.66  136.99
# String:
# Databases    isudns
# Hosts        localhost
# Users        isudns
# Query_time distribution
#   1us
#  10us
# 100us  #######
#   1ms  #################
#  10ms  ################################################################
# 100ms
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isudns` LIKE 'records'\G
#    SHOW CREATE TABLE `isudns`.`records`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT content,ttl,prio,type,domain_id,disabled,name,auth FROM records WHERE disabled=0 and name='878pbzzfvfw97v6xy1c6z16m0.u.isucon.local' and domain_id=1\G

# Query 3: 17.66 QPS, 0.31x concurrency, ID 0x3D83BC87F3B3A00D571FFC8104A6E50C at byte 63053696
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.01
# Time range: 2024-12-02T07:22:34 to 2024-12-02T07:24:22
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          0    1907
# Exec time      8     34s   566us   107ms    18ms    46ms    15ms    14ms
# Lock time      4    48ms     1us    31ms    25us     2us   701us     1us
# Rows sent      0     985       0       1    0.52    0.99    0.50    0.99
# Rows examine   5   2.41M   1.25k   1.33k   1.29k   1.26k   24.70   1.26k
# Query size     1 254.31k     128     209  136.56  158.58   11.59  124.25
# String:
# Databases    isudns
# Hosts        localhost
# Users        isudns
# Query_time distribution
#   1us
#  10us
# 100us  #########
#   1ms  #######################
#  10ms  ################################################################
# 100ms  #
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isudns` LIKE 'records'\G
#    SHOW CREATE TABLE `isudns`.`records`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT content,ttl,prio,type,domain_id,disabled,name,auth FROM records WHERE disabled=0 and type='SOA' and name='u.isucon.local'\G

# Query 4: 26.49 QPS, 0.28x concurrency, ID 0xDB74D52D39A7090F224C4DEEAF3028C9 at byte 73459599
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.05
# Time range: 2024-12-02T07:22:53 to 2024-12-02T07:24:22
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          0    2358
# Exec time      6     25s   901us   141ms    11ms    68ms    23ms     1ms
# Lock time      0     3ms     1us    65us     1us     1us     1us     1us
# Rows sent      2   2.30k       1       1       1       1       0       1
# Rows examine  11   4.57M   1.96k   2.16k   1.99k   2.06k   68.94   1.96k
# Query size     1 333.37k     143     146  144.77  143.84    0.94  143.84
# String:
# Databases    isupipe
# Hosts        localhost
# Users        isucon
# Query_time distribution
#   1us
#  10us
# 100us  ################
#   1ms  ################################################################
#  10ms  #############
# 100ms  #
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isupipe` LIKE 'users'\G
#    SHOW CREATE TABLE `isupipe`.`users`\G
#    SHOW TABLE STATUS FROM `isupipe` LIKE 'livestreams'\G
#    SHOW CREATE TABLE `isupipe`.`livestreams`\G
#    SHOW TABLE STATUS FROM `isupipe` LIKE 'reactions'\G
#    SHOW CREATE TABLE `isupipe`.`reactions`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT COUNT(*) FROM users u
		INNER JOIN livestreams l ON l.user_id = u.id
		INNER JOIN reactions r ON r.livestream_id = l.id
		WHERE u.id = 59\G

# Query 5: 60.76 QPS, 0.26x concurrency, ID 0x38BC86A45F31C6B1EE324671506C898A at byte 76106187
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.01
# Time range: 2024-12-02T07:22:53 to 2024-12-02T07:24:22
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          2    5408
# Exec time      5     23s   187us    77ms     4ms    19ms     8ms   725us
# Lock time      1    11ms       0     2ms     2us     1us    33us     1us
# Rows sent      4   5.28k       1       1       1       1       0       1
# Rows examine  13   5.34M    1000   1.06k   1.01k   1.04k   32.37 1012.63
# Query size     0 214.68k      38      41   40.65   40.45    0.91   40.45
# String:
# Databases    isupipe
# Hosts        localhost
# Users        isucon
# Query_time distribution
#   1us
#  10us
# 100us  ################################################################
#   1ms  ###########################################
#  10ms  ##############
# 100ms
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isupipe` LIKE 'themes'\G
#    SHOW CREATE TABLE `isupipe`.`themes`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT * FROM themes WHERE user_id = 1013\G

# Query 6: 26.46 QPS, 0.25x concurrency, ID 0xF1B8EF06D6CA63B24BFF433E06CCEB22 at byte 61324965
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.05
# Time range: 2024-12-02T07:22:53 to 2024-12-02T07:24:22
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          0    2355
# Exec time      5     22s   994us   122ms    10ms    61ms    21ms     1ms
# Lock time      0     4ms     1us   459us     1us     1us     9us     1us
# Rows sent      2   2.30k       1       1       1       1       0       1
# Rows examine  11   4.56M   1.96k   2.15k   1.98k   2.06k   68.84   1.96k
# Query size     1 378.95k     163     166  164.77  158.58       0  158.58
# String:
# Databases    isupipe
# Hosts        localhost
# Users        isucon
# Query_time distribution
#   1us
#  10us
# 100us
#   1ms  ################################################################
#  10ms  ##########
# 100ms  #
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isupipe` LIKE 'users'\G
#    SHOW CREATE TABLE `isupipe`.`users`\G
#    SHOW TABLE STATUS FROM `isupipe` LIKE 'livestreams'\G
#    SHOW CREATE TABLE `isupipe`.`livestreams`\G
#    SHOW TABLE STATUS FROM `isupipe` LIKE 'livecomments'\G
#    SHOW CREATE TABLE `isupipe`.`livecomments`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT IFNULL(SUM(l2.tip), 0) FROM users u
		INNER JOIN livestreams l ON l.user_id = u.id	
		INNER JOIN livecomments l2 ON l2.livestream_id = l.id
		WHERE u.id = 1\G

# Query 7: 73.43 QPS, 0.19x concurrency, ID 0x84B457C910C4A79FC9EBECB8B1065C66 at byte 80192232
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.01
# Time range: 2024-12-02T07:22:53 to 2024-12-02T07:24:22
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          2    6535
# Exec time      4     17s    42us    66ms     3ms    12ms     6ms   403us
# Lock time      6    63ms       0    23ms     9us     1us   358us     1us
# Rows sent      3   3.98k       0       1    0.62    0.99    0.48    0.99
# Rows examine   0   3.98k       0       1    0.62    0.99    0.48    0.99
# Query size     1 278.51k      41      44   43.64   42.48    0.38   42.48
# String:
# Databases    isupipe
# Hosts        localhost
# Users        isucon
# Query_time distribution
#   1us
#  10us  ######################
# 100us  ################################################################
#   1ms  ##################################################
#  10ms  ########
# 100ms
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isupipe` LIKE 'icons'\G
#    SHOW CREATE TABLE `isupipe`.`icons`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT image FROM icons WHERE user_id = 1001\G

# Query 8: 3.90 QPS, 0.19x concurrency, ID 0x59F1B6DD8D9FEC059E55B3BFD624E8C3 at byte 61331058
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.01
# Time range: 2024-12-02T07:22:53 to 2024-12-02T07:24:21
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          0     343
# Exec time      4     16s     2ms   155ms    48ms    87ms    26ms    46ms
# Lock time      0   446us     1us     2us     1us     1us       0     1us
# Rows sent      0     343       1       1       1       1       0       1
# Rows examine   7   2.87M   8.55k   8.55k   8.55k   8.55k       0   8.55k
# Query size     0  28.81k      86      86      86      86       0      86
# String:
# Databases    isupipe
# Hosts        localhost
# Users        isucon
# Query_time distribution
#   1us
#  10us
# 100us
#   1ms  #######
#  10ms  ################################################################
# 100ms  ###
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isupipe` LIKE 'reservation_slots'\G
#    SHOW CREATE TABLE `isupipe`.`reservation_slots`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT slot FROM reservation_slots WHERE start_at = 1701054000 AND end_at = 1701057600\G

# Query 9: 1.58 QPS, 0.19x concurrency, ID 0x64CC8A4E8E4B390203375597CE4D611F at byte 49663652
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.02
# Time range: 2024-12-02T07:23:04 to 2024-12-02T07:24:22
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          0     123
# Exec time      3     15s     4ms   215ms   122ms   180ms    49ms   128ms
# Lock time      0   166us     1us     3us     1us     1us       0     1us
# Rows sent      0       7       0       1    0.06       0    0.23       0
# Rows examine   4   1.68M  14.00k  14.01k  14.00k  13.78k       0  13.78k
# Query size     0  11.89k      97      99   98.97   97.36    0.59   97.36
# String:
# Databases    isupipe
# Hosts        localhost
# Users        isucon
# Query_time distribution
#   1us
#  10us
# 100us
#   1ms  #######
#  10ms  #############
# 100ms  ################################################################
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isupipe` LIKE 'ng_words'\G
#    SHOW CREATE TABLE `isupipe`.`ng_words`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT id, user_id, livestream_id, word FROM ng_words WHERE user_id = 1016 AND livestream_id = 7530\G

# Query 10: 123.66 QPS, 0.21x concurrency, ID 0x4ADE2DC90689F1C4891749AF54FB8D14 at byte 57547300
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.01
# Time range: 2024-12-02T07:23:21 to 2024-12-02T07:24:22
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          2    7543
# Exec time      3     13s    36us    80ms     2ms     7ms     5ms   113us
# Lock time     12   120ms       0    31ms    15us     1us   555us     1us
# Rows sent      0       0       0       0       0       0       0       0
# Rows examine   0  14.74k       2       4    2.00    1.96    0.03    1.96
# Query size     9   2.37M     263     417  329.67  363.48   25.25  313.99
# String:
# Databases    isupipe
# Hosts        localhost
# Users        isucon
# Query_time distribution
#   1us
#  10us  ################################################################
# 100us  ##########################################################
#   1ms  ##########################################
#  10ms  ######
# 100ms
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isupipe` LIKE 'livecomments'\G
#    SHOW CREATE TABLE `isupipe`.`livecomments`\G
DELETE FROM livecomments
			WHERE
			id = 362 AND
			livestream_id = 7528 AND
			(SELECT COUNT(*)
			FROM
			(SELECT 'このトピックに深く触れてくれて感謝しています。' AS text) AS texts
			INNER JOIN
			(SELECT CONCAT('%', '緑益補強', '%')	AS pattern) AS patterns
			ON texts.text LIKE patterns.pattern) >= 1\G
# Converted for EXPLAIN
# EXPLAIN /*!50100 PARTITIONS*/
select * from  livecomments
			WHERE
			id = 362 AND
			livestream_id = 7528 AND
			(SELECT COUNT(*)
			FROM
			(SELECT 'このトピックに深く触れてくれて感謝しています。' AS text) AS texts
			INNER JOIN
			(SELECT CONCAT('%', '緑益補強', '%')	AS pattern) AS patterns
			ON texts.text LIKE patterns.pattern) >= 1\G

# Query 11: 167.30 QPS, 0.16x concurrency, ID 0xFBC5564AE716EAE82F20BFB45F6C37E7 at byte 51404046
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.01
# Time range: 2024-12-02T07:23:13 to 2024-12-02T07:24:22
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          4   11544
# Exec time      2     11s    23us    71ms   968us     4ms     4ms    89us
# Lock time     10    99ms       0    28ms     8us     1us   323us     1us
# Rows sent      9  11.27k       1       1       1       1       0       1
# Rows examine   0  11.27k       1       1       1       1       0       1
# Query size     1 360.21k      31      33   31.95   31.70    0.47   31.70
# String:
# Databases    isupipe
# Hosts        localhost
# Users        isucon
# Query_time distribution
#   1us
#  10us  ################################################################
# 100us  #########################
#   1ms  ################
#  10ms  ##
# 100ms
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isupipe` LIKE 'tags'\G
#    SHOW CREATE TABLE `isupipe`.`tags`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT * FROM tags WHERE id = 25\G

# Query 12: 12.37 QPS, 0.12x concurrency, ID 0xFFFCA4D67EA0A788813031B8BBC3B329 at byte 53090401
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.01
# Time range: 2024-12-02T07:22:53 to 2024-12-02T07:24:22
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          0    1101
# Exec time      2     11s    18us   107ms    10ms    28ms    10ms     8ms
# Lock time      0       0       0       0       0       0       0       0
# Rows sent      0       0       0       0       0       0       0       0
# Rows examine   0       0       0       0       0       0       0       0
# Query size     0   6.45k       6       6       6       6       0       6
# String:
# Databases    isupipe (1019/92%), isudns (82/7%)
# Hosts        localhost
# Users        isucon (1019/92%), isudns (82/7%)
# Query_time distribution
#   1us
#  10us  ####################
# 100us  ########################
#   1ms  ######################################
#  10ms  ################################################################
# 100ms  #
#    1s
#  10s+
COMMIT\G

# Query 13: 66.67 QPS, 0.50x concurrency, ID 0xDFFCC1D78939C4D781C7C58349101F50 at byte 542118
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.00
# Time range: 2024-12-02T07:22:35 to 2024-12-02T07:22:50
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          0    1000
# Exec time      1      8s     3ms    26ms     8ms    10ms     2ms     7ms
# Lock time      0     3ms     1us   420us     2us     2us    12us     1us
# Rows sent      0       0       0       0       0       0       0       0
# Rows examine   0       0       0       0       0       0       0       0
# Query size     1 401.18k     192     463  410.81  420.77   16.87  400.73
# String:
# Databases    isupipe
# Hosts        localhost
# Users        isucon
# Query_time distribution
#   1us
#  10us
# 100us
#   1ms  ################################################################
#  10ms  ####
# 100ms
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isupipe` LIKE 'users'\G
#    SHOW CREATE TABLE `isupipe`.`users`\G
INSERT INTO users (id, name, display_name, description, password) VALUES (608, 'harukawatanabe0', 'ぶどうぶどうぶん', '普段脚本家をしています。\nよろしくおねがいします！\n\n連絡は以下からお願いします。\n\nウェブサイト: http://harukawatanabe.example.com/\nメールアドレス: harukawatanabe@example.com\n', '$2a$04$sLLGF.m9gbfbm5pTeUjpvuW89BW.yNEylciEbeGzsacMmbCN1DnSC')\G

# Query 14: 27.52 QPS, 0.07x concurrency, ID 0x22279D81D51006139E0C76405B54C261 at byte 46396913
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.01
# Time range: 2024-12-02T07:22:34 to 2024-12-02T07:24:22
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          1    2972
# Exec time      1      7s    69us    49ms     3ms    13ms     5ms   301us
# Lock time      1    13ms     1us     2ms     4us     2us    43us     1us
# Rows sent      0       0       0       0       0       0       0       0
# Rows examine   0       0       0       0       0       0       0       0
# Query size     1 336.67k     116     116     116     116       0     116
# String:
# Databases    isudns
# Hosts        localhost
# Users        isudns
# Query_time distribution
#   1us
#  10us  ##
# 100us  ################################################################
#   1ms  #############################
#  10ms  #######
# 100ms
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isudns` LIKE 'domains'\G
#    SHOW CREATE TABLE `isudns`.`domains`\G
#    SHOW TABLE STATUS FROM `isudns` LIKE 'domainmetadata'\G
#    SHOW CREATE TABLE `isudns`.`domainmetadata`\G
# EXPLAIN /*!50100 PARTITIONS*/
select kind,content from domains, domainmetadata where domainmetadata.domain_id=domains.id and name='u.isucon.local'\G

# Query 15: 10.20 QPS, 0.07x concurrency, ID 0xD2A0864774622BA36F6557496405CF75 at byte 72185042
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.00
# Time range: 2024-12-02T07:22:35 to 2024-12-02T07:24:21
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          0    1081
# Exec time      1      7s    55us    33ms     7ms     9ms     2ms     7ms
# Lock time      0     3ms     1us   252us     2us     2us     7us     1us
# Rows sent      0       0       0       0       0       0       0       0
# Rows examine   0       0       0       0       0       0       0       0
# Query size     0  61.37k      55      60   58.13   56.92    0.73   56.92
# String:
# Databases    isupipe
# Hosts        localhost
# Users        isucon
# Query_time distribution
#   1us
#  10us  #
# 100us  #
#   1ms  ################################################################
#  10ms  ##
# 100ms
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isupipe` LIKE 'themes'\G
#    SHOW CREATE TABLE `isupipe`.`themes`\G
INSERT INTO themes (user_id, dark_mode) VALUES(1072, 1)\G

# Query 16: 21.23 QPS, 0.02x concurrency, ID 0x8F7679D452333ED3C7D60D22131CEFD4 at byte 66407302
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.01
# Time range: 2024-12-02T07:17:18 to 2024-12-02T07:24:22
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          3    9001
# Exec time      1      7s     6us    87ms   817us     4ms     3ms    49us
# Lock time      0       0       0       0       0       0       0       0
# Rows sent      0       0       0       0       0       0       0       0
# Rows examine   0       0       0       0       0       0       0       0
# Query size     1 290.07k      33      33      33      33       0      33
# String:
# Databases    isudns
# Hosts        localhost
# Users        isudns
# Query_time distribution
#   1us  ########
#  10us  ################################################################
# 100us  ###############
#   1ms  ##############
#  10ms  ##
# 100ms
#    1s
#  10s+
administrator command: Reset stmt\G

# Query 17: 881.88 QPS, 0.33x concurrency, ID 0xFD38427AE3D09E3883A680F7BAF95D3A at byte 11693527
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.00
# Time range: 2024-12-02T07:22:56 to 2024-12-02T07:23:13
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          5   14992
# Exec time      1      6s   203us     4ms   378us     1ms   290us   273us
# Lock time      2    22ms     1us   927us     1us     1us    13us     1us
# Rows sent     12  14.64k       1       1       1       1       0       1
# Rows examine  35  14.33M    1001    1003    1002  964.41       0  964.41
# Query size     7   1.71M     117     120  119.85  118.34    0.64  118.34
# String:
# Databases    isupipe
# Hosts        localhost
# Users        isucon
# Query_time distribution
#   1us
#  10us
# 100us  ################################################################
#   1ms  ###
#  10ms
# 100ms
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isupipe` LIKE 'livestreams'\G
#    SHOW CREATE TABLE `isupipe`.`livestreams`\G
#    SHOW TABLE STATUS FROM `isupipe` LIKE 'livecomments'\G
#    SHOW CREATE TABLE `isupipe`.`livecomments`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT IFNULL(SUM(l2.tip), 0) FROM livestreams l INNER JOIN livecomments l2 ON l.id = l2.livestream_id WHERE l.id = 3081\G

# Query 18: 0.63 QPS, 0.06x concurrency, ID 0x7F9C0C0BA9473953B723EE16C08655F1 at byte 63094515
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.09
# Time range: 2024-12-02T07:22:53 to 2024-12-02T07:24:22
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          0      56
# Exec time      1      5s     6ms   268ms    96ms   241ms    93ms    91ms
# Lock time      0    82us     1us     2us     1us     1us       0     1us
# Rows sent      0     355       1      20    6.34   18.53    6.29    2.90
# Rows examine   1 479.01k   8.55k   8.55k   8.55k   8.55k       0   8.55k
# Query size     0   5.25k      96      96      96      96       0      96
# String:
# Databases    isupipe
# Hosts        localhost
# Users        isucon
# Query_time distribution
#   1us
#  10us
# 100us
#   1ms  ################################################################
#  10ms  ####
# 100ms  ################################################################
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isupipe` LIKE 'reservation_slots'\G
#    SHOW CREATE TABLE `isupipe`.`reservation_slots`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT * FROM reservation_slots WHERE start_at >= 1701003600 AND end_at <= 1701018000 FOR UPDATE\G

# Query 19: 0.61 QPS, 0.06x concurrency, ID 0xA3401CA3ABCC04C3AB221DB8AD5CBF26 at byte 53428559
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.08
# Time range: 2024-12-02T07:22:53 to 2024-12-02T07:24:21
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          0      54
# Exec time      1      5s     6ms   260ms    96ms   230ms    90ms    82ms
# Lock time      0    76us     1us     2us     1us     1us       0     1us
# Rows sent      0       0       0       0       0       0       0       0
# Rows examine   1 461.90k   8.55k   8.55k   8.55k   8.55k       0   8.55k
# Query size     0   5.17k      98      98      98      98       0      98
# String:
# Databases    isupipe
# Hosts        localhost
# Users        isucon
# Query_time distribution
#   1us
#  10us
# 100us
#   1ms  ################################################################
#  10ms  ####
# 100ms  ################################################################
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isupipe` LIKE 'reservation_slots'\G
#    SHOW CREATE TABLE `isupipe`.`reservation_slots`\G
UPDATE reservation_slots SET slot = slot - 1 WHERE start_at >= 1700967600 AND end_at <= 1701003600\G
# Converted for EXPLAIN
# EXPLAIN /*!50100 PARTITIONS*/
select  slot = slot - 1 from reservation_slots where  start_at >= 1700967600 AND end_at <= 1701003600\G

# Query 20: 59.81 QPS, 0.06x concurrency, ID 0xEA1E6309EEEFF9A6831AD2FB940FC23C at byte 78698368
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.01
# Time range: 2024-12-02T07:22:53 to 2024-12-02T07:24:22
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          1    5323
# Exec time      1      5s    34us    76ms   926us     4ms     3ms    93us
# Lock time      4    39ms       0    19ms     7us     1us   288us     1us
# Rows sent      4   5.20k       1       1       1       1       0       1
# Rows examine   0   5.20k       1       1       1       1       0       1
# Query size     0 180.09k      32      35   34.64   34.95    0.90   34.95
# String:
# Databases    isupipe
# Hosts        localhost
# Users        isucon
# Query_time distribution
#   1us
#  10us  ################################################################
# 100us  #########################################
#   1ms  ####################
#  10ms  ##
# 100ms
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isupipe` LIKE 'users'\G
#    SHOW CREATE TABLE `isupipe`.`users`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT * FROM users WHERE id = 1019\G
```

### アクセスログ

```
make alp
sudo cat /var/log/nginx/access.log | alp ltsv --config=/home/isucon/config/alp.yml > /home/isucon/log/access.log-2024-12-02-07-26-36
sudo rm /var/log/nginx/access.log
cat /home/isucon/log/access.log-2024-12-02-07-26-36
+-------+-----+--------+-----------------------------------------------------------------------------------------------------+--------+--------+---------+--------+--------+
| COUNT | 5XX | METHOD |                                                 URI                                                 |  MIN   |  MAX   |   SUM   |  AVG   |  P99   |
+-------+-----+--------+-----------------------------------------------------------------------------------------------------+--------+--------+---------+--------+--------+
| 1135  | 0   | GET    | /api/user/.+/icon                                                                                   | 0.001  | 1.650  | 167.854 | 0.148  | 0.951  |
| 124   | 0   | GET    | /api/livestream/\d+/livecomment                                                                     | 0.004  | 2.215  | 93.716  | 0.756  | 1.889  |
| 158   | 0   | GET    | /api/livestream/\d+/reaction                                                                        | 0.001  | 2.027  | 81.780  | 0.518  | 1.889  |
| 7     | 0   | POST   | /api/livestream/\d+/moderate                                                                        | 0.320  | 14.294 | 80.682  | 11.526 | 14.294 |
| 5     | 0   | GET    | /api/user/.+/statistics                                                                             | 3.084  | 20.014 | 60.105  | 12.021 | 20.014 |
| 19    | 0   | GET    | /api/livestream/search?limit=50                                                                     | 0.076  | 5.165  | 56.661  | 2.982  | 5.165  |
| 153   | 0   | POST   | /api/livestream/\d+/livecomment                                                                     | 0.006  | 1.494  | 56.549  | 0.370  | 1.293  |
| 83    | 1   | POST   | /api/register                                                                                       | 0.001  | 1.802  | 52.771  | 0.636  | 1.802  |
| 58    | 0   | POST   | /api/livestream/reservation                                                                         | 0.173  | 2.147  | 41.264  | 0.711  | 2.147  |
| 123   | 0   | POST   | /api/livestream/\d+/reaction                                                                        | 0.010  | 0.730  | 26.077  | 0.212  | 0.587  |
| 78    | 5   | POST   | /api/icon                                                                                           | 0.032  | 1.224  | 21.156  | 0.271  | 1.224  |
| 1     | 0   | POST   | /api/initialize                                                                                     | 19.008 | 19.008 | 19.008  | 19.008 | 19.008 |
| 2     | 0   | GET    | /api/livestream/\d+/statistics                                                                      | 5.989  | 7.309  | 13.298  | 6.649  | 7.309  |
| 89    | 0   | POST   | /api/login                                                                                          | 0.001  | 1.261  | 9.580   | 0.108  | 1.261  |
| 1     | 0   | GET    | /api/livestream/search?tag=%E3%82%A2%E3%82%AF%E3%82%B7%E3%83%A7%E3%83%B3%E3%82%B2%E3%83%BC%E3%83%A0 | 8.334  | 8.334  | 8.334   | 8.334  | 8.334  |
| 1     | 0   | GET    | /api/livestream/search?tag=%E3%83%A1%E3%82%A4%E3%82%AF                                              | 8.065  | 8.065  | 8.065   | 8.065  | 8.065  |
| 31    | 0   | GET    | /api/livestream                                                                                     | 0.018  | 1.257  | 7.418   | 0.239  | 1.257  |
| 1     | 0   | GET    | /api/livestream/search?tag=%E3%82%B7%E3%83%B3%E3%82%B0%E3%83%AB%E3%83%97%E3%83%AC%E3%82%A4          | 7.121  | 7.121  | 7.121   | 7.121  | 7.121  |
| 36    | 0   | GET    | /api/tag                                                                                            | 0.001  | 0.941  | 4.349   | 0.121  | 0.941  |
| 19    | 0   | GET    | /api/livestream/\d+/report                                                                          | 0.001  | 0.769  | 3.049   | 0.160  | 0.769  |
| 13    | 0   | GET    | /api/livestream/\d+/ngwords                                                                         | 0.008  | 0.393  | 2.700   | 0.208  | 0.393  |
| 1     | 0   | GET    | /api/livestream/search?tag=%E3%82%B3%E3%83%B3%E3%82%B5%E3%83%BC%E3%83%88                            | 2.622  | 2.622  | 2.622   | 2.622  | 2.622  |
| 16    | 0   | POST   | /api/livestream/\d+/enter                                                                           | 0.010  | 1.176  | 2.178   | 0.136  | 1.176  |
| 8     | 0   | DELETE | /api/livestream/\d+/exit                                                                            | 0.009  | 0.279  | 0.710   | 0.089  | 0.279  |
| 1     | 0   | GET    | /api/livestream/search?tag=%E3%83%A9%E3%82%A4%E3%83%96%E9%85%8D%E4%BF%A1                            | 0.238  | 0.238  | 0.238   | 0.238  | 0.238  |
| 1     | 0   | GET    | /api/livestream/search?tag=%E6%A4%85%E5%AD%90                                                       | 0.234  | 0.234  | 0.234   | 0.234  | 0.234  |
| 1     | 0   | GET    | /api/livestream/search?tag=%E4%B8%8D%E5%8B%95%E7%94%A3                                              | 0.234  | 0.234  | 0.234   | 0.234  | 0.234  |
| 1     | 0   | GET    | /api/livestream/search?tag=%E3%83%9B%E3%83%A9%E3%83%BC%E3%82%B2%E3%83%BC%E3%83%A0                   | 0.218  | 0.218  | 0.218   | 0.218  | 0.218  |
| 1     | 0   | GET    | /api/livestream/search?tag=%E3%83%A8%E3%82%AC                                                       | 0.217  | 0.217  | 0.217   | 0.217  | 0.217  |
| 1     | 0   | GET    | /api/livestream/search?tag=%E6%89%8B%E7%9B%B8                                                       | 0.207  | 0.207  | 0.207   | 0.207  | 0.207  |
| 1     | 0   | GET    | /api/livestream/search?tag=%E3%83%97%E3%83%AD%E3%82%B2%E3%83%BC%E3%83%9E%E3%83%BC                   | 0.202  | 0.202  | 0.202   | 0.202  | 0.202  |
| 1     | 0   | GET    | /api/livestream/search?tag=%E6%9C%9D%E6%B4%BB                                                       | 0.201  | 0.201  | 0.201   | 0.201  | 0.201  |
| 1     | 0   | GET    | /api/livestream/search?tag=%E3%83%9E%E3%83%AB%E3%83%81%E3%83%97%E3%83%AC%E3%82%A4                   | 0.201  | 0.201  | 0.201   | 0.201  | 0.201  |
| 4     | 0   | GET    | /api/user/.+/theme                                                                                  | 0.002  | 0.082  | 0.168   | 0.042  | 0.082  |
| 3     | 0   | GET    | /api/user/me                                                                                        | 0.002  | 0.005  | 0.009   | 0.003  | 0.005  |
| 1     | 0   | GET    | /api/payment                                                                                        | 0.007  | 0.007  | 0.007   | 0.007  | 0.007  |
| 1     | 0   | GET    | /api/livestream/\d+                                                                                 | 0.006  | 0.006  | 0.006   | 0.006  | 0.006  |
| 1     | 0   | GET    | /api/user/test                                                                                      | 0.002  | 0.002  | 0.002   | 0.002  | 0.002  |
+-------+-----+--------+-----------------------------------------------------------------------------------------------------+--------+--------+---------+--------+--------+
```